### PR TITLE
Adding a Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ pickle-email-*.html
 .idea/*
 ~*
 /_site
+Gemfile.lock
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+ruby RUBY_VERSION
+
+gem 'github-pages', group: :jekyll_plugins
+
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]


### PR DESCRIPTION
Adding a Gemfile that tracks to GitHub's pages gem so that folks can build the docs locally to preview their changes.

Ignored Gemfile.lock so any downstream vulnerabilities don't trigger an alert on GitHub.